### PR TITLE
Add note about MCP servers release (mcp-hey and mcp-whatsapp)

### DIFF
--- a/src/src/content/note/2026-04-18-mcp-hey-mcp-whatsapp.mdx
+++ b/src/src/content/note/2026-04-18-mcp-hey-mcp-whatsapp.mdx
@@ -1,8 +1,9 @@
 ---
-description: "Published two MCP servers today: mcp-hey and mcp-whatsapp. mcp-whatsapp is a fork, rewritten as a full whatsmeow wrapper rather than a bridge. Use at your own risk - worth reading both apps' automation policies first, since neither is exactly keen on this sort of thing."
-pubDateTime: "2026-04-18T18:44:00.000Z"
+description: "Published two MCP servers today: mcp-hey and mcp-whatsapp. mcp-hey for hey.com automation and mcp-whatsapp is a fork, rewritten as a full whatsmeow wrapper rather than a bridge. Use at your own risk - both companies owning the underlying services are not the biggest fans of self-service automation =]"
+pubDateTime: "2026-04-18T20:40:00.000Z"
 tags: ["mcp", "opensource", "automation"]
-externalUrl: "https://github.com/sealjay/mcp-hey"
+externalUrl: "https://github.com/Sealjay/mcp-hey"
 externalPlatform: "GitHub"
 isHighlight: false
+mastodonUrl: "https://fosstodon.org/@sealjay/116427407092515028"
 ---

--- a/src/src/content/note/2026-04-18-mcp-hey-mcp-whatsapp.mdx
+++ b/src/src/content/note/2026-04-18-mcp-hey-mcp-whatsapp.mdx
@@ -1,6 +1,6 @@
 ---
 description: "Published two MCP servers today: mcp-hey and mcp-whatsapp. mcp-hey for hey.com automation and mcp-whatsapp is a fork, rewritten as a full whatsmeow wrapper rather than a bridge. Use at your own risk - both companies owning the underlying services are not the biggest fans of self-service automation =]"
-pubDateTime: "2026-04-18T20:40:00.000Z"
+pubDateTime: "2026-04-18T19:40:00.000Z"
 tags: ["mcp", "opensource", "automation"]
 externalUrl: "https://github.com/Sealjay/mcp-hey"
 externalPlatform: "GitHub"

--- a/src/src/content/note/2026-04-18-mcp-hey-mcp-whatsapp.mdx
+++ b/src/src/content/note/2026-04-18-mcp-hey-mcp-whatsapp.mdx
@@ -1,0 +1,8 @@
+---
+description: "Published two MCP servers today: mcp-hey and mcp-whatsapp. mcp-whatsapp is a fork, rewritten as a full whatsmeow wrapper rather than a bridge. Use at your own risk - worth reading both apps' automation policies first, since neither is exactly keen on this sort of thing."
+pubDateTime: "2026-04-18T18:44:00.000Z"
+tags: ["mcp", "opensource", "automation"]
+externalUrl: "https://github.com/sealjay/mcp-hey"
+externalPlatform: "GitHub"
+isHighlight: false
+---


### PR DESCRIPTION
## Summary
Added a new blog post documenting the release of two MCP (Model Context Protocol) servers: mcp-hey and mcp-whatsapp.

## Changes
- Created new content note dated 2026-04-18 announcing the publication of mcp-hey and mcp-whatsapp MCP servers
- mcp-hey: automation server for hey.com
- mcp-whatsapp: a rewritten fork that functions as a full whatsmeow wrapper rather than a bridge
- Includes metadata with tags (mcp, opensource, automation), GitHub link, and Mastodon cross-post reference
- Includes disclaimer about usage risks given the underlying services' stance on self-service automation

## Details
The post is marked as non-highlighted and includes proper frontmatter with publication timestamp, external URL reference, and social media cross-posting information.

https://claude.ai/code/session_01793NjMFboeLmdSzrt4oSmr