### PR TITLE
Add mcp-hey and mcp-whatsapp project documentation

### DIFF
--- a/src/src/content/project/mcp-hey.mdx
+++ b/src/src/content/project/mcp-hey.mdx
@@ -1,0 +1,11 @@
+---
+title: "mcp-hey"
+description: "MCP server for Hey.com: read, send, search, and organise email from Claude or any MCP client. Runs locally, stores no credentials, respects rate limits."
+repoUrl: "https://github.com/Sealjay/mcp-hey"
+techStack: ["TypeScript", "Bun", "MCP", "SQLite"]
+status: "Active"
+date: "2026-04-18T00:00:00.000Z"
+tags: ["MCP", "AI", "Email", "Claude"]
+---
+
+MCP server for [Hey.com](https://hey.com) email that exposes read, send, search, and organise tools to [Claude](https://claude.ai) or any Model Context Protocol client. Runs locally, stores no credentials, and respects rate limits.

--- a/src/src/content/project/mcp-whatsapp.mdx
+++ b/src/src/content/project/mcp-whatsapp.mdx
@@ -1,0 +1,11 @@
+---
+title: "mcp-whatsapp"
+description: "Single-binary Go MCP server that wraps whatsmeow to expose a personal WhatsApp account as 41 MCP tools (messaging, groups, polls, media, privacy)."
+repoUrl: "https://github.com/Sealjay/mcp-whatsapp"
+techStack: ["Go", "MCP", "whatsmeow", "SQLite"]
+status: "Active"
+date: "2026-04-18T00:00:00.000Z"
+tags: ["MCP", "AI", "WhatsApp", "Messaging"]
+---
+
+Single-binary Go MCP server that wraps [whatsmeow](https://github.com/tulir/whatsmeow) to expose a personal WhatsApp account as 41 Model Context Protocol tools covering messaging, groups, polls, media, and privacy.


### PR DESCRIPTION
## Summary
Added documentation for two new MCP (Model Context Protocol) server projects to the project portfolio.

## Changes
- **mcp-hey**: New project documentation for a TypeScript/Bun-based MCP server that integrates Hey.com email with Claude and other MCP clients. Provides tools for reading, sending, searching, and organizing emails with local execution and no credential storage.
- **mcp-whatsapp**: New project documentation for a Go-based MCP server that exposes WhatsApp functionality through 41 MCP tools, covering messaging, groups, polls, media management, and privacy controls.

## Details
Both projects are documented with:
- Comprehensive metadata (title, description, repository URL, tech stack)
- Active status with consistent date stamps
- Relevant tags for discoverability (MCP, AI, and service-specific tags)
- Brief descriptions highlighting key features and implementation approach

https://claude.ai/code/session_019sy5jtT7cgr1tkGYuP5dh4