### PR TITLE
fix(scripts): fail loudly when sync tokens are missing

### DIFF
--- a/src/src/scripts/sync-mastodon-toots.mjs
+++ b/src/src/scripts/sync-mastodon-toots.mjs
@@ -409,8 +409,8 @@ async function ensureUniqueSlug(slug) {
 async function main() {
   const token = process.env.MASTODON_TOKEN
   if (!token) {
-    console.log('MASTODON_TOKEN not set, skipping Mastodon toot sync.')
-    return
+    console.error('MASTODON_TOKEN not set — aborting.')
+    process.exit(1)
   }
 
   const state = await loadState()

--- a/src/src/scripts/sync-webmentions.mjs
+++ b/src/src/scripts/sync-webmentions.mjs
@@ -106,8 +106,8 @@ function findLatestTimestamp(data) {
 async function main() {
   const token = process.env.WEBMENTION_IO_TOKEN
   if (!token) {
-    console.log('WEBMENTION_IO_TOKEN not set, skipping webmention sync.')
-    return
+    console.error('WEBMENTION_IO_TOKEN not set — aborting.')
+    process.exit(1)
   }
 
   const existing = await loadExisting()


### PR DESCRIPTION
## Summary
- Sync scripts (`sync-mastodon-toots.mjs`, `sync-webmentions.mjs`) now `process.exit(1)` when their token env var is unset, instead of silently returning with exit code 0
- This would have surfaced the stale `MASTODON_TOKEN` secret ~7 weeks ago instead of producing green no-op CI runs

## Context
The weekly content sync workflow has been silently skipping since ~2026-03-14 because `MASTODON_TOKEN` was invalid/empty. The script logged a message and returned successfully, so the workflow showed green.

## Test plan
- [ ] Verify `MASTODON_TOKEN` GitHub secret has been rotated (done — set via `gh secret set`)
- [ ] Next Monday cron run should either sync new toots or fail visibly

🤖 Generated with [Claude Code](https://claude.com/claude-code)