### PR TITLE
chore: migrate mdx plugins to unified() processor (mdx 6)

### DIFF
--- a/src/astro.config.mjs
+++ b/src/astro.config.mjs
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { unified } from '@astrojs/markdown-remark'
 import mdx from '@astrojs/mdx'
 import sitemap from '@astrojs/sitemap'
 import tailwind from '@astrojs/tailwind'
@@ -224,8 +225,13 @@ export default defineConfig({
     }),
     tailwind(),
     mdx({
-      remarkPlugins: [remarkRewriteImagePaths],
-      rehypePlugins: [rehypeMvpUrl],
+      // mdx 6 deprecated remarkPlugins/rehypePlugins here; pass them through a
+      // unified() processor instead. Scoped to mdx() (not markdown.processor)
+      // so plain .md files keep their existing behaviour.
+      processor: unified({
+        remarkPlugins: [remarkRewriteImagePaths],
+        rehypePlugins: [rehypeMvpUrl],
+      }),
     }),
   ],
 })


### PR DESCRIPTION
## What

mdx 6 deprecated passing `remarkPlugins`/`rehypePlugins` directly to `mdx({...})` (they trigger a build-time deprecation warning and will be removed in a future major). This moves the site's two custom plugins — `remarkRewriteImagePaths` and `rehypeMvpUrl` — into a `unified()` processor from `@astrojs/markdown-remark`, as recommended by the warning.

## Why scoped to `mdx()` and not `markdown.processor`

The plugins were previously attached to the `mdx()` integration, so they only ran on `.mdx` files — the single plain `.md` post (`finding-azure-openai-resources.md`) was never processed by them. Using `mdx({ processor: unified({...}) })` preserves that exact scoping rather than silently extending the plugins to `.md` content.

## Verification

Built locally (`bun run build`) and checked the output:

- ✅ Microsoft links in mdx bodies still carry `?WT.mc_id=AI-MVP-5004204`
- ✅ Content `/images/...` paths still compile to `/_astro/*.webp`
- ✅ Shiki syntax highlighting intact (`astro-code` classes present)
- ✅ Deprecation warning gone; `bun run build` and `bun run lint` both pass

The remaining untagged `*.microsoft.com` links are all in frontmatter `url:` fields / `personal.ts`, which rehype plugins never processed — unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)