### PR TITLE
feat: tag microsoft.com links in frontmatter, config and embeds with MVP id

### DIFF
--- a/src/src/components/embeds/SocialEmbed.astro
+++ b/src/src/components/embeds/SocialEmbed.astro
@@ -1,4 +1,6 @@
 ---
+import { tagMvpUrl } from '../../lib/mvp-url'
+
 type Props = {
   title: string
   linkUrl: string
@@ -6,10 +8,12 @@ type Props = {
 }
 
 const { title, linkUrl, imageUrl } = Astro.props
+// Tag *.microsoft.com embeds with the MVP tracking param (no-op for others)
+const href = tagMvpUrl(linkUrl)
 ---
 
 <div class="social-embed">
-  <a href={linkUrl} target="_blank" rel="noopener noreferrer" class="social-embed-link">
+  <a href={href} target="_blank" rel="noopener noreferrer" class="social-embed-link">
     <div class="social-embed-container">
       <div class="social-embed-content">
         <h3 class="social-embed-title">{title}</h3>

--- a/src/src/config/personal.ts
+++ b/src/src/config/personal.ts
@@ -1,3 +1,5 @@
+import { tagMvpUrl } from '../lib/mvp-url'
+
 // Professional badges/affiliations
 export interface Badge {
   text: string
@@ -19,7 +21,7 @@ export const professionalBadges: Badge[] = [
   // Homepage badges (first 3 shown on homepage, all shown on About)
   {
     text: '6x Microsoft MVP in AI',
-    url: 'https://mvp.microsoft.com/en-US/mvp/profile/224176f9-f3a7-eb11-b1ac-000d3a53daf4',
+    url: tagMvpUrl('https://mvp.microsoft.com/en-US/mvp/profile/224176f9-f3a7-eb11-b1ac-000d3a53daf4'),
   },
   {
     text: 'Doctoral Student, Green AI (UEL, 2022\u20132027)',

--- a/src/src/content.config.ts
+++ b/src/src/content.config.ts
@@ -1,6 +1,7 @@
 import { defineCollection } from 'astro:content'
 import { glob } from 'astro/loaders'
 import { z } from 'astro/zod'
+import { tagMvpUrl } from './lib/mvp-url'
 
 const authorSchema = z.object({
   name: z.string(),
@@ -34,7 +35,11 @@ const blog = defineCollection({
         .transform((str) => (str ? new Date(str) : undefined)),
       heroImage: image().optional(),
       tags: z.array(z.string()).optional(),
-      sourceUrl: z.string().url().optional(),
+      sourceUrl: z
+        .string()
+        .url()
+        .optional()
+        .transform((u) => (u ? tagMvpUrl(u) : u)),
       featured: z.boolean().default(false),
       inReplyTo: z.string().url().optional(),
       additionalAuthors: z.array(authorSchema).optional(),
@@ -54,7 +59,9 @@ const speaking = defineCollection({
         .or(z.date())
         .transform((val) => new Date(val)),
       cta: z.string(),
-      url: z.string().url(),
+      // Tag *.microsoft.com links with the MVP tracking param; these live in
+      // frontmatter so the rehype-mvp-url plugin never sees them.
+      url: z.string().url().transform(tagMvpUrl),
       thumbnail: image().optional(),
       blogPostSlug: z.string().optional(),
       featured: z.boolean().default(false),
@@ -71,7 +78,11 @@ const note = defineCollection({
       .or(z.date())
       .transform((val) => new Date(val)),
     tags: z.array(z.string()).optional(),
-    externalUrl: z.string().url().optional(),
+    externalUrl: z
+      .string()
+      .url()
+      .optional()
+      .transform((u) => (u ? tagMvpUrl(u) : u)),
     externalPlatform: z
       .enum(['LinkedIn', 'X', 'GitHub', 'Mastodon', 'YouTube', 'Article', 'Web', 'HuggingFace'])
       .optional(),
@@ -112,7 +123,7 @@ const acknowledgement = defineCollection({
     description: z.string(),
     notes: z.string(),
     image: z.string(),
-    url: z.string().url(),
+    url: z.string().url().transform(tagMvpUrl),
     licence: z.string(),
     licenceUrl: z.string().url(),
   }),

--- a/src/src/lib/mvp-url.ts
+++ b/src/src/lib/mvp-url.ts
@@ -1,0 +1,42 @@
+const MVP_ID = 'AI-MVP-5004204'
+
+function isMicrosoftUrl(hostname: string): boolean {
+  return hostname.endsWith('.microsoft.com') || hostname === 'microsoft.com'
+}
+
+/**
+ * Append the Microsoft MVP tracking parameter (`WT.mc_id`) to `*.microsoft.com`
+ * URLs, replacing any existing one. Non-Microsoft URLs and unparseable strings
+ * are returned unchanged, so this is safe to apply to any outbound link.
+ *
+ * Used by the `rehype-mvp-url` plugin for links inside rendered markdown, and by
+ * content/config schemas for links that live in frontmatter or static config
+ * (which the rehype plugin never sees).
+ */
+export function tagMvpUrl(href: string): string {
+  let url: URL
+  try {
+    url = new URL(href)
+  } catch {
+    return href
+  }
+
+  if (!isMicrosoftUrl(url.hostname)) {
+    return href
+  }
+
+  // Strip existing WT.mc_id (case-insensitive) before setting the canonical one
+  const keysToDelete: string[] = []
+  for (const key of url.searchParams.keys()) {
+    if (key.toLowerCase() === 'wt.mc_id') {
+      keysToDelete.push(key)
+    }
+  }
+  for (const key of keysToDelete) {
+    url.searchParams.delete(key)
+  }
+
+  url.searchParams.set('WT.mc_id', MVP_ID)
+
+  return url.toString()
+}

--- a/src/src/plugins/rehype-mvp-url.ts
+++ b/src/src/plugins/rehype-mvp-url.ts
@@ -1,39 +1,6 @@
 import type { Element, Properties, Root } from 'hast'
 import { visit } from 'unist-util-visit'
-
-const MVP_ID = 'AI-MVP-5004204'
-
-function isMicrosoftUrl(hostname: string): boolean {
-  return hostname.endsWith('.microsoft.com') || hostname === 'microsoft.com'
-}
-
-function processHref(href: string): string {
-  let url: URL
-  try {
-    url = new URL(href)
-  } catch {
-    return href
-  }
-
-  if (!isMicrosoftUrl(url.hostname)) {
-    return href
-  }
-
-  // Strip existing WT.mc_id (case-insensitive)
-  const keysToDelete: string[] = []
-  for (const key of url.searchParams.keys()) {
-    if (key.toLowerCase() === 'wt.mc_id') {
-      keysToDelete.push(key)
-    }
-  }
-  for (const key of keysToDelete) {
-    url.searchParams.delete(key)
-  }
-
-  url.searchParams.set('WT.mc_id', MVP_ID)
-
-  return url.toString()
-}
+import { tagMvpUrl } from '../lib/mvp-url'
 
 export default function rehypeMvpUrl(): (tree: Root) => void {
   return (tree: Root): void => {
@@ -43,7 +10,7 @@ export default function rehypeMvpUrl(): (tree: Root) => void {
       const props: Properties | undefined = node.properties
       if (!props?.href || typeof props.href !== 'string') return
 
-      props.href = processHref(props.href)
+      props.href = tagMvpUrl(props.href)
     })
   }
 }


### PR DESCRIPTION
## Problem

The `rehype-mvp-url` plugin only appends the MVP tracking param (`?WT.mc_id=AI-MVP-5004204`) to `*.microsoft.com` links that appear **inside rendered markdown bodies**. Microsoft links that live in **frontmatter**, **static config**, or **Astro component props** were never tagged — e.g. speaking-entry `url:` fields, the MVP badge in `personal.ts`, and `<SocialEmbed linkUrl=...>` embeds.

## Change

- Extract the tagging logic into a shared `src/lib/mvp-url.ts` (`tagMvpUrl`); `rehype-mvp-url` now imports it.
- Apply `tagMvpUrl` via zod transforms on `content.config.ts`, so every consumer (components, search JSON, RSS) gets the tagged URL automatically:
  - speaking `url`
  - blog `sourceUrl`
  - note `externalUrl`
  - acknowledgement `url`
- Tag the Microsoft MVP badge URL in `config/personal.ts`.
- Tag `linkUrl` in the `SocialEmbed` component.

`tagMvpUrl` is a no-op for non-Microsoft URLs and unparseable strings, so the transforms are safe on fields that usually point elsewhere.

## Deliberately excluded

- Acknowledgement `licenceUrl` (e.g. `microsoft.com/licensing/terms`) — adding a personal MVP tracking code to a generic licence-terms page is semantically wrong.
- `search.json` / `feed.json` raw-content extraction — tracking params there are search/feed noise.

## Verification

Built locally and grepped the output:

- ✅ Previously-untagged links now carry `WT.mc_id` (SocialEmbed `mybuild.microsoft.com`, acknowledgement `learn.microsoft.com` SWA URL, `personal.ts` MVP profile, speaking `build.microsoft.com`)
- ✅ Markdown-body links still tagged (unchanged behaviour via the refactored plugin)
- ✅ `licenceUrl` remains untagged (the only `*.microsoft.com` link left in rendered HTML, as intended)
- ✅ `bun run build` and `bun run lint` both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)