### PR TITLE
content: add notes (MS Build, Securing the Realm, Scottish Summit)

### DIFF
--- a/src/src/content/note/2026-05-28-msbuild-cli.mdx
+++ b/src/src/content/note/2026-05-28-msbuild-cli.mdx
@@ -1,0 +1,8 @@
+---
+description: "Next week is #MSBuild in San Francisco — two days on real, production AI systems. I'm proctoring the lab on engineering agents that reason, act, and adapt, so come get hands-on. What says \"this is for builders\" to me is the Build CLI: a GitHub Copilot CLI skill that reads your project, finds relevant sessions, and even scaffolds from the one you're in. Still spots in person and online — if you're there, say hi, I'll try to look up from my terminal."
+pubDateTime: "2026-05-28T18:48:00.000Z"
+tags: ["ai", "agents", "msbuild", "github"]
+externalUrl: "https://www.linkedin.com/posts/chrislloydjones_github-microsoftbuild-cli-experience-share-7465836302605750275-Zeld/"
+externalPlatform: "LinkedIn"
+daySummary: "MS Build week in San Francisco - proctoring the agents lab and loving the new Build CLI - plus a new Securing the Realm episode with Nema Sobhani on operationalising AI in the enterprise."
+---

--- a/src/src/content/note/2026-05-28-securing-the-realm-nema-sobhani.mdx
+++ b/src/src/content/note/2026-05-28-securing-the-realm-nema-sobhani.mdx
@@ -1,0 +1,7 @@
+---
+description: "New Securing the Realm episode with Nema Sobhani on operationalising AI in the enterprise. Once agents start doing real work on their own, they stop being tools and start reshaping the org-chart — and as Josh McDonald says, evaluation and governance is the control system for how AI shows up at work, not a box you tick at the end. Favourite line: \"is clanker considered a curse word?\" You bear the consequences, not the model."
+pubDateTime: "2026-05-28T04:46:00.000Z"
+tags: ["ai", "aigovernance", "securingtherealm", "podcast"]
+externalUrl: "https://www.linkedin.com/posts/chrislloydjones_ai-aigovernance-mvpbuzz-share-7465624500760514560-5pay/"
+externalPlatform: "LinkedIn"
+---

--- a/src/src/content/note/2026-06-14-scottish-summit-2026.mdx
+++ b/src/src/content/note/2026-06-14-scottish-summit-2026.mdx
@@ -1,0 +1,7 @@
+---
+description: "Scottish Summit 2026 is fast approaching — I'm on the workshop speaker line-up and can't wait to demo the AI gateway!"
+pubDateTime: "2026-06-14T23:08:00.000Z"
+tags: ["ai", "scottishsummit", "speaking"]
+externalUrl: "https://www.linkedin.com/posts/scottish-summit-2026-workshop-speaker-line-up-ugcPost-7458102609967644673-Uhin/"
+externalPlatform: "LinkedIn"
+---


### PR DESCRIPTION
## Add three notes (LinkedIn backfill)

Short-form notes added to the `note` collection, dated to their source posts (timestamps derived from the LinkedIn activity IDs), each linking back to the post:

- **2026-05-28** — Securing the Realm episode with Nema Sobhani (operationalising AI in the enterprise)
- **2026-05-28** — MS Build CLI / proctoring the agents lab (this one carries the shared day-summary)
- **2026-06-14** (today) — Scottish Summit 2026, AI gateway demo

No Fosstodon syndication. `bun run build` ✓ (generates `/notes/2026-05-28/` and `/notes/2026-06-14/`).

Still to come (awaiting post text): MVP Summit / agentic AI (2026-03-26) and MVP Summit agentic-security roundup (2026-04-17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
